### PR TITLE
Add yaml version of example template

### DIFF
--- a/templates/example_template.yaml
+++ b/templates/example_template.yaml
@@ -1,0 +1,84 @@
+Project:
+  name: testproject
+  permission:
+    - Team: teamA
+      acl: admin
+    - Team: teamB
+      acl: view
+  Folder:
+    - name: folderA
+      annotations:
+        test: me
+      permission:
+        - Team: teamA
+          acl: admin
+        - Team: teamB
+          acl: view
+      Folder:
+        - name: innerfolderB
+          Folder: []
+      File:
+        - name: entityname
+          filepath: /test/my/path
+  Forum:
+    - Thread:
+        title: Example thread
+        messageMarkdown: '#my markdown'
+        Reply:
+          - messageMarkdown: response
+  Challenge:
+    Team: teamA
+  Table:
+    - name: tableA
+      description: user description of schema
+      annotations:
+        key: pair
+      Column:
+        - name: column1
+          defaultValue: temp
+          maximumSize: 1000
+          columnType: STRING
+          facetType: enumeration
+        - name: column2
+          defaultValue: 2
+          columnType: INTEGER
+          facetType: range
+  annotations:
+    key: pair
+  Evaluation:
+    - name: test queue
+      description: This is a testing queue
+      submissionInstructionsMessage: Instrucitons here
+      submissionReceiptMessage: Successful submission!
+      quota:
+        firstRoundStart: 11111
+        roundDurationMillis: 1
+        numberOfRounds: 2
+        submissionLimit: 5
+      permission:
+        - Team: teamA
+          acl: admin
+        - Team: teamB
+          acl: view
+  _wiki_structure:
+    - title: My wiki
+      markdown: My markdown
+      subwiki:
+        - title: subwiki
+          markdown: subwiki content
+          subwiki: []
+    - title: Second wiki
+      markdown: Content
+      subwiki: []
+  Wiki: syn12345
+Team:
+  - name: teamA
+    description: This is a testing team
+    canPublicJoin: true
+    invitees:
+      - 3333
+  - name: teamB
+    description: This is another team
+    canPublicJoin: false
+    invitees:
+      - 2222


### PR DESCRIPTION
I thought it might be useful to have a YAML version of the example template. This was generated from `example_template.json` using the utility cfn-flip.